### PR TITLE
Explicit dependency on Interfaces 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 * Changed autoloading from PSR-0 to PSR-4
 * Added tests for DimensionValidator
 
-### 0.1 (2013-11-17)
+### 0.1.0 (2013-11-17)
 
 Initial release with these features:
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
-		"data-values/interfaces": "~0.1"
+		"data-values/interfaces": "~0.2.0|~0.1.0"
 	},
 	"autoload": {
 		"files" : [


### PR DESCRIPTION
As far as I know ~0.1 includes all versions <1.0. This may not be a good idea because the 0.x versions are allowed to contain breaking changes. Better be explicit.