### PR TITLE
Add missing ListValidatorTest

### DIFF
--- a/src/ListValidator.php
+++ b/src/ListValidator.php
@@ -30,26 +30,22 @@ class ListValidator extends ValueValidatorObject {
 			return;
 		}
 
-		$validator = new RangeValidator();
+		$options = array();
 
 		if ( array_key_exists( 'elementcount', $this->options ) ) {
-			$range = $this->options['elementcount'];
-
-			if ( !is_array( $range ) || count( $range ) !== 2 ) {
-				throw new Exception( 'The elementcount option must be an array with two elements' );
-			}
-
-			$validator->setRange( $range[0], $range[1] );
+			$options['range'] = $this->options['elementcount'];
 		}
 
-		// min- and maxelements options are allowed to overwrite the elementcount option!
 		if ( array_key_exists( 'minelements', $this->options ) ) {
-			$validator->setLowerBound( $this->options['minelements'] );
-		}
-		if ( array_key_exists( 'maxelements', $this->options ) ) {
-			$validator->setUpperBound( $this->options['maxelements'] );
+			$options['lowerbound'] = $this->options['minelements'];
 		}
 
+		if ( array_key_exists( 'maxelements', $this->options ) ) {
+			$options['upperbound'] = $this->options['maxelements'];
+		}
+
+		$validator = new RangeValidator();
+		$validator->setOptions( $options );
 		$this->runSubValidator( count( $value ), $validator, 'length' );
 	}
 

--- a/src/NullValidator.php
+++ b/src/NullValidator.php
@@ -19,7 +19,7 @@ class NullValidator implements ValueValidator {
 	 *
 	 * @param mixed $value
 	 *
-	 * @return Result
+	 * @return Result Always successfull.
 	 */
 	public function validate( $value ) {
 		return Result::newSuccess();

--- a/tests/ValueValidators/ListValidatorTest.php
+++ b/tests/ValueValidators/ListValidatorTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace ValueValidators\Tests;
+
+use PHPUnit_Framework_TestCase;
+use ValueValidators\Error;
+use ValueValidators\ListValidator;
+
+/**
+ * @covers ValueValidators\ListValidator
+ *
+ * @group ValueValidators
+ * @group DataValueExtensions
+ *
+ * @licence GNU GPL v2+
+ * @author Thiemo Mättig
+ */
+class ListValidatorTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider invalidRangeProvider
+	 */
+	public function testInvalidRange( $range ) {
+		$validator = new ListValidator();
+		$validator->setOptions( [ 'elementcount' => $range ] );
+		$this->setExpectedException( 'Exception' );
+		$validator->validate( [] );
+	}
+
+	public function invalidRangeProvider() {
+		return [
+			[ null ],
+			[ 0 ],
+			[ '' ],
+			[ [] ],
+			[ [ 0 ] ],
+			[ [ 0, 0, 0 ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider valueProvider
+	 */
+	public function testValidate( $value, array $options, $expectedErrors ) {
+		$validator = new ListValidator();
+		$validator->setOptions( $options );
+		$result = $validator->validate( $value );
+
+		if ( !is_array( $expectedErrors ) ) {
+			$expectedErrors = [ $expectedErrors ];
+		}
+
+		$this->assertEquals( $expectedErrors, $result->getErrors() );
+	}
+
+	public function valueProvider() {
+		return [
+			[
+				'value' => null,
+				'options' => [],
+				'expectedErrors' => Error::newError( 'Not an array' )
+			],
+			[
+				'value' => 0,
+				'options' => [],
+				'expectedErrors' => Error::newError( 'Not an array' )
+			],
+			[
+				'value' => '',
+				'options' => [],
+				'expectedErrors' => Error::newError( 'Not an array' )
+			],
+			[
+				'value' => [],
+				'options' => [],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [],
+				'expectedErrors' => []
+			],
+
+			// Lower bound only
+			[
+				'value' => [],
+				'options' => [ 'minelements' => null ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'minelements' => 0 ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'minelements' => 1 ],
+				'expectedErrors' => Error::newError( 'Value exceeding lower bound', 'length' )
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'minelements' => 1 ],
+				'expectedErrors' => []
+			],
+
+			// Upper bound only
+			[
+				'value' => [],
+				'options' => [ 'maxelements' => null ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'maxelements' => 0 ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'maxelements' => 0 ],
+				'expectedErrors' => Error::newError( 'Value exceeding upper bound', 'length' )
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'maxelements' => 1 ],
+				'expectedErrors' => []
+			],
+
+			// Lower and upper bound
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 0, 0 ] ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'elementcount' => [ 2, 2 ] ],
+				'expectedErrors' => Error::newError( 'Value exceeding lower bound', 'length' )
+			],
+			[
+				'value' => [ 1, 2 ],
+				'options' => [ 'elementcount' => [ 2, 2 ] ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'elementcount' => [ 0, 0 ] ],
+				'expectedErrors' => Error::newError( 'Value exceeding upper bound', 'length' )
+			],
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 0, 0 ] ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 2, 0 ] ],
+				'expectedErrors' => Error::newError( 'Value exceeding lower bound', 'length' )
+			],
+			[
+				'value' => [ 1, 2 ],
+				'options' => [ 'elementcount' => [ 2, 0 ] ],
+				'expectedErrors' => Error::newError( 'Value exceeding upper bound', 'length' )
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'elementcount' => [ 2, 0 ] ],
+				'expectedErrors' => [
+					Error::newError( 'Value exceeding upper bound', 'length' ),
+					Error::newError( 'Value exceeding lower bound', 'length' ),
+				]
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'minelements' => 2, 'maxelements' => 0 ],
+				'expectedErrors' => [
+					Error::newError( 'Value exceeding upper bound', 'length' ),
+					Error::newError( 'Value exceeding lower bound', 'length' ),
+				]
+			],
+
+			// Conflicting options
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 1, 1 ], 'minelements' => null ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 1, 1 ], 'minelements' => false ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'elementcount' => [ 1, 1 ], 'minelements' => 0 ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [],
+				'options' => [ 'minelements' => 0, 'elementcount' => [ 1, 1 ] ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'elementcount' => [ 0, 0 ], 'maxelements' => false ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'elementcount' => [ 0, 0 ], 'maxelements' => 1 ],
+				'expectedErrors' => []
+			],
+			[
+				'value' => [ 1 ],
+				'options' => [ 'maxelements' => 1, 'elementcount' => [ 0, 0 ] ],
+				'expectedErrors' => []
+			],
+		];
+	}
+
+}


### PR DESCRIPTION
The reason I'm touching this is the 4th parameter of the `runSubValidator` method. This is the only call that uses this 4th parameter. I would love to get rid of this, see https://github.com/DataValues/Interfaces/pull/24.

This is the first step necessary to get rid of `ValueValidator::setOptions`.

Pinging @brightbyte, since he marked about 10 implementations of `setOptions` as "This method shouldn't even be in the interface".
