### PR TITLE
[DNM] Deprecate all setOptions methods

### DIFF
--- a/src/DimensionValidator.php
+++ b/src/DimensionValidator.php
@@ -229,6 +229,7 @@ class DimensionValidator extends ValueValidatorObject {
 	 * @see ValueValidator::setOptions
 	 *
 	 * @since 0.1
+	 * @deprecated since 0.1.3, remove when support for DataValues Interfaces 0.2 is dropped
 	 *
 	 * @param array $options
 	 * @throws Exception

--- a/src/NullValidator.php
+++ b/src/NullValidator.php
@@ -29,6 +29,7 @@ class NullValidator implements ValueValidator {
 	 * @see ValueValidator::setOptions
 	 *
 	 * @since 0.1
+	 * @deprecated since 0.1.3, remove when support for DataValues Interfaces 0.2 is dropped
 	 *
 	 * @param array $options
 	 */

--- a/src/RangeValidator.php
+++ b/src/RangeValidator.php
@@ -131,6 +131,7 @@ class RangeValidator extends ValueValidatorObject {
 	 * @see ValueValidator::setOptions
 	 *
 	 * @since 0.1
+	 * @deprecated since 0.1.3, remove when support for DataValues Interfaces 0.2 is dropped
 	 *
 	 * @param array $options
 	 * @throws Exception

--- a/src/TitleValidator.php
+++ b/src/TitleValidator.php
@@ -51,6 +51,7 @@ class TitleValidator extends ValueValidatorObject {
 	 * @see ValueValidator::setOptions
 	 *
 	 * @since 0.1
+	 * @deprecated since 0.1.3, remove when support for DataValues Interfaces 0.2 is dropped
 	 *
 	 * @param array $options
 	 */


### PR DESCRIPTION
I'm working on the removal of this method in DataValues Interfaces 0.3. It's currently used in a single place, but that's not necessary, see #11.

The implementations in this component should not be removed to fast, to not break compatibility with older DataValues Interfaces versions.
